### PR TITLE
Adds npm testpr script compatible with win and mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "nodemon app.js",
     "build": "node_modules/.bin/webpack -d",
     "build:watch": "node_modules/.bin/webpack -d --watch",
-    "testpr": "npm install && npm run build && start http://localhost:8080 && nodemon app.js"
+    "testpr": "bash testpr.sh"
   },
   "repository": {
     "type": "git",

--- a/testpr.sh
+++ b/testpr.sh
@@ -1,13 +1,13 @@
-#/!/bin/bash
+#!/bin/bash
 START= command -v start
 OPEN= command -v open
 
 npm install
 npm run build
-if [ -n START ]
+if [ -n START ];
 then
 start http://localhost:8080
-elif [ -n OPEN ]
+elif [ -n OPEN ];
 then
 open http://localhost:8080
 fi

--- a/testpr.sh
+++ b/testpr.sh
@@ -1,0 +1,14 @@
+#/!/bin/bash
+START= command -v start
+OPEN= command -v open
+
+npm install
+npm run build
+if [ -n START ]
+then
+start http://localhost:8080
+elif [ -n OPEN ]
+then
+open http://localhost:8080
+fi
+nodemon app.js

--- a/testpr.sh
+++ b/testpr.sh
@@ -7,7 +7,8 @@ npm run build
 if [ -n START ];
 then
 start http://localhost:8080
-elif [ -n OPEN ];
+fi
+if [ -n OPEN ];
 then
 open http://localhost:8080
 fi


### PR DESCRIPTION
Can someone with a  mac test the command `npm run testpr`?

Also test: `bash testpr`

They should do the same thing